### PR TITLE
Validate AoC ID in LinkCommand

### DIFF
--- a/notifier/aoc_bot/modules/link_command.py
+++ b/notifier/aoc_bot/modules/link_command.py
@@ -119,6 +119,12 @@ class LinkCommand:
                 )
                 return
 
+            if self.aoc_id <= 0:
+                await ctx.respond(
+                    "Invalid AoC ID.", ephemeral=True
+                )
+                return
+            
             aoc_username = get_aoc_name_from_aoc_id(self.aoc_id)
             for k, v in mapping.items():
                 if k == self.aoc_id and v == ctx.user.id:


### PR DESCRIPTION
Validate AoC ID to ensure its greater than 0
Currently it just proceeds as normal
I dont think it would break anything, but making it more robust cant hurt

Example:
<img width="503" height="109" alt="image" src="https://github.com/user-attachments/assets/82135cc2-cac4-456e-8547-e94838580ec2" />
